### PR TITLE
Fix Edge not being detected correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,33 @@ export default class DetectOS {
     dataBrowser() {
         return [
             /***************
+             * Edge
+             ***************/
+            {
+                string: navigator.userAgent,
+                subString: "Edge",
+                identity: "Edge",
+                versionSearch: "Edge"
+            },
+            {
+                string: navigator.userAgent,
+                subString: "Edg",
+                identity: "Edge",
+                versionSearch: "Edg"
+            },
+            {
+                string: navigator.userAgent,
+                subString: "EdgA",
+                identity: "Edge",
+                versionSearch: "EdgA"
+            },
+            {
+                string: navigator.userAgent,
+                subString: "EdgiOS",
+                identity: "Edge",
+                versionSearch: "EdgiOS"
+            },
+            /***************
              * Chrome
              ***************/
             {
@@ -71,15 +98,6 @@ export default class DetectOS {
                 subString: "Trident",
                 identity: "IE11",
                 versionSearch: "rv"
-            },
-            /***************
-             * Edge
-             ***************/
-            {
-                string: navigator.userAgent,
-                subString: "Edge",
-                identity: "Edge",
-                versionSearch: "Edge"
             },
             /***************
              * Firefox


### PR DESCRIPTION
Hi,

Edge seems to have [changed their userAgent string](https://www.whatismybrowser.com/guides/the-latest-user-agent/edge) - they moved from "Edge" to "Edg" / "EdgA" / "EdgiOS" depending on the platform.  

Example from Windows:  
`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36 Edg/92.0.902.55`

According to the [official guide](https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance), user agent client hints are now the preferred method of detecting browser versions (although navigator.userAgentData is only implemented by Chrome, Edge and Opera at the moment). Are you planning on supporting this way of detection in a later version, or would you prefer keeping it dependent on navigator props implemented by all browsers?

In case you would like to keep things as is, this PR adds the new userAgent markers. I had to bump Edge above Chrome in the list, otherwise the search functions still return Chrome.


Unrelated FYI - [@types/detectos.js](https://www.npmjs.com/package/@types/detectos.js) is now a thing.